### PR TITLE
Imports ordering feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ Options:
   --help                Show this message and exit.
 ```
 
+### Ordering imports in existing file
+
+```
+starknet-interface-generator order-imports [OPTIONS]
+
+Options:
+  --files TEXT          Contract to order imports in
+  --help                Show this message and exit.
+```
+
 ## Example
 
 Generate interfaces for the contracts in `contracts/` and put them in `interfaces/`:

--- a/src/cli.py
+++ b/src/cli.py
@@ -39,12 +39,22 @@ def check(protostar: bool, directory: str, files: List[str]):
 
 # this command may be run with:
 # python src/cli.py order-imports -f test/main_imports_test.cairo -i starkware -i openzeppelin
+# python src/cli.py order-imports -d test/ -i starkware -i openzeppelin
 @click.command()
+@click.option('--directory', '-d', help="Directory with cairo files to format")
 @click.option("--files", '-f', multiple=True, default=[], help="File paths")
 @click.option("--imports", '-i', multiple=True, default=["starkware", "openzeppelin"], help="Imports order")
-def order_imports(files: List[str], imports: List[str]):
+def order_imports(directory: str, files: List[str], imports: List[str]):
+    files_to_order = []
+    if len(directory) > 0:
+        path = os.path.join(os.getcwd(), directory)
+        for (root,_,cairo_files) in os.walk(path, topdown=True):
+            for f in cairo_files:
+                files_to_order.append(os.path.join(root, f))
+    else:
+        files_to_order = files
 
-    sys.exit(generate_ordered_imports(files, imports))
+    sys.exit(generate_ordered_imports(files_to_order, imports))
 
 cli.add_command(generate)
 cli.add_command(check)

--- a/src/cli.py
+++ b/src/cli.py
@@ -40,11 +40,7 @@ def check(protostar: bool, directory: str, files: List[str]):
 
 @click.command()
 @click.option("--files", '-f', multiple=True, default=[], help="File paths")
-@click.option('--directory', '-d', help='Output directory for the interfaces. If unspecified, they will be created in the same directory as the contracts')
 def order_imports(directory: str, files: List[str]):
-    # if protostar:
-    #     protostar_path = os.path.join(os.getcwd(), "protostar.toml")
-    #     files = get_contracts_from_protostar(protostar_path)
 
     sys.exit(generate_ordered_imports(directory, files))
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -5,7 +5,7 @@ import traceback
 
 from typing import List
 from starkware.cairo.lang.version import __version__
-from src.logic import check_files, generate_interfaces, get_contracts_from_protostar, print_version
+from logic import check_files, generate_interfaces, get_contracts_from_protostar, print_version, generate_ordered_imports
 
 
 @click.group()
@@ -38,9 +38,19 @@ def check(protostar: bool, directory: str, files: List[str]):
     sys.exit(check_files(directory, files))
 
 
+@click.command()
+@click.option("--files", '-f', multiple=True, default=[], help="File paths")
+@click.option('--directory', '-d', help='Output directory for the interfaces. If unspecified, they will be created in the same directory as the contracts')
+def order_imports(directory: str, files: List[str]):
+    # if protostar:
+    #     protostar_path = os.path.join(os.getcwd(), "protostar.toml")
+    #     files = get_contracts_from_protostar(protostar_path)
+
+    sys.exit(generate_ordered_imports(directory, files))
+
 cli.add_command(generate)
 cli.add_command(check)
-
+cli.add_command(order_imports)
 
 def main():
     cli()

--- a/src/cli.py
+++ b/src/cli.py
@@ -46,7 +46,7 @@ def check(protostar: bool, directory: str, files: List[str]):
 @click.option("--imports", '-i', multiple=True, default=["starkware", "openzeppelin"], help="Imports order")
 def order_imports(directory: str, files: List[str], imports: List[str]):
     files_to_order = []
-    if len(directory) > 0:
+    if directory:
         path = os.path.join(os.getcwd(), directory)
         for (root,_,cairo_files) in os.walk(path, topdown=True):
             for f in cairo_files:

--- a/src/cli.py
+++ b/src/cli.py
@@ -37,12 +37,14 @@ def check(protostar: bool, directory: str, files: List[str]):
         files = get_contracts_from_protostar(protostar_path)
     sys.exit(check_files(directory, files))
 
-
+# this command may be run with:
+# python src/cli.py order-imports -f test/main_imports_test.cairo -i starkware -i openzeppelin
 @click.command()
 @click.option("--files", '-f', multiple=True, default=[], help="File paths")
-def order_imports(directory: str, files: List[str]):
+@click.option("--imports", '-i', multiple=True, default=["starkware", "openzeppelin"], help="Imports order")
+def order_imports(files: List[str], imports: List[str]):
 
-    sys.exit(generate_ordered_imports(directory, files))
+    sys.exit(generate_ordered_imports(files, imports))
 
 cli.add_command(generate)
 cli.add_command(check)

--- a/src/logic.py
+++ b/src/logic.py
@@ -3,12 +3,13 @@ from typing import Dict, List
 import click
 import toml
 import os
+import subprocess 
 from starkware.cairo.lang.compiler.ast.module import CairoModule
 from starkware.cairo.lang.compiler.parser import parse_file
 
 from starknet_interface_generator.generator import Generator
 from starknet_interface_generator.interface_parser import InterfaceParser
-
+from starknet_interface_generator.order_imports import OrderImports
 
 def cairo_parser(code, filename): return parse_file(
     code=code, filename=filename)
@@ -56,6 +57,28 @@ def generate_interfaces(directory: str, files: List[str]):
         open(newpath, "w").write(formatted_interface)
     return 0
 
+def generate_ordered_imports(directory: str, files: List[str]):
+    for path in files:
+        contract_file = open(path).read()
+        _, filename = os.path.split(path)
+
+        try:
+            # Generate the AST of the cairo contract, visit it and generate the interface
+            contract = CairoModule(
+                cairo_file=cairo_parser(contract_file, filename),
+                module_name=path,
+            )
+            order_imports = OrderImports().create_ordered_imports(contract)
+
+            subprocess.call(['sed','-i','/.*import.*/d', path])
+            insert_line = f'2 i {order_imports}'
+            subprocess.call(["sed","-i", f"{insert_line}", path])
+        
+        except Exception as exc:
+            print(traceback.format_exc())
+            return 1
+
+    return 0
 
 def check_files(directory, files):
     errors = []

--- a/src/logic.py
+++ b/src/logic.py
@@ -68,16 +68,16 @@ def generate_ordered_imports(directory: str, files: List[str]):
                 cairo_file=cairo_parser(contract_file, filename),
                 module_name=path,
             )
-            order_imports = OrderImports().create_ordered_imports(contract)
+            contract_ordered = OrderImports(["starkware", "openzeppelin"]).create_ordered_imports(contract)
+            print(contract_ordered.cairo_file.format())
+            # contract_ordered_formatted = contract_ordered.format()
 
-            subprocess.call(['sed','-i','/.*import.*/d', path])
-            insert_line = f'2 i {order_imports}'
-            subprocess.call(["sed","-i", f"{insert_line}", path])
         
         except Exception as exc:
             print(traceback.format_exc())
             return 1
 
+        # open(path, "w").write(contract_ordered)
     return 0
 
 def check_files(directory, files):

--- a/src/logic.py
+++ b/src/logic.py
@@ -69,8 +69,7 @@ def generate_ordered_imports(directory: str, files: List[str]):
                 module_name=path,
             )
             contract_ordered = OrderImports(["starkware", "openzeppelin"]).create_ordered_imports(contract)
-            print(contract_ordered.cairo_file.format())
-            # contract_ordered_formatted = contract_ordered.format()
+            # TODO: Cairo module seems ok, but can't run .format() method on it
 
         
         except Exception as exc:

--- a/src/logic.py
+++ b/src/logic.py
@@ -57,7 +57,7 @@ def generate_interfaces(directory: str, files: List[str]):
         open(newpath, "w").write(formatted_interface)
     return 0
 
-def generate_ordered_imports(directory: str, files: List[str]):
+def generate_ordered_imports(files: List[str], imports: List[str]):
     for path in files:
         contract_file = open(path).read()
         _, filename = os.path.split(path)
@@ -68,15 +68,14 @@ def generate_ordered_imports(directory: str, files: List[str]):
                 cairo_file=cairo_parser(contract_file, filename),
                 module_name=path,
             )
-            contract_ordered = OrderImports(["starkware", "openzeppelin"]).create_ordered_imports(contract)
-            # TODO: Cairo module seems ok, but can't run .format() method on it
-
+            OrderImports([*imports]).create_ordered_imports(contract)
+            contract = contract.format()
         
         except Exception as exc:
             print(traceback.format_exc())
             return 1
 
-        # open(path, "w").write(contract_ordered)
+        open(path, "w").write(contract)
     return 0
 
 def check_files(directory, files):

--- a/src/starknet_interface_generator/order_imports.py
+++ b/src/starknet_interface_generator/order_imports.py
@@ -2,7 +2,7 @@ from multiprocessing import allow_connection_pickling
 from symbol import import_name
 from typing import List, Dict
 from collections import OrderedDict
-from starkware.cairo.lang.compiler.ast.code_elements import CodeBlock, CodeElementImport, CodeElementEmptyLine
+from starkware.cairo.lang.compiler.ast.code_elements import CodeBlock, CodeElementImport, CodeElementEmptyLine, CommentedCodeElement
 from starkware.cairo.lang.compiler.ast.visitor import Visitor
 
 class OrderImports(Visitor):
@@ -22,38 +22,33 @@ class OrderImports(Visitor):
         return self.extract_imports(elm)
     
     def extract_imports(self, elm):
-        empty_element = self.get_empty_element(elm)
+        empty_element = self.get_empty_element()
         all_imports: Dict[str, List] = OrderedDict()
-        temp_import_order_names = self.import_order_names + ["rest"]
 
-        all_imports = {x: [empty_element] for x in temp_import_order_names}
+        all_imports = {x: [empty_element] for x in self.import_order_names}
         code_elements = elm.code_elements
             
         for i, x in enumerate(code_elements):
             if isinstance(x.code_elm, CodeElementImport):
-                for import_order_name in temp_import_order_names:
-                    if (import_order_name not in self.import_order_names):
-                        all_imports["rest"].append(x)
-                        break
-                    elif (import_order_name in x.code_elm.path.name):
+                import_first_word = x.code_elm.path.name.split(".")[0]
+                # group additional elements if not specified in initial list
+                if import_first_word not in self.import_order_names:
+                    self.import_order_names.append(import_first_word)
+                    all_imports[import_first_word] = [empty_element]
+                for import_order_name in self.import_order_names:
+                    if (import_order_name == x.code_elm.path.name.split(".")[0]):
                         all_imports[import_order_name].append(x)
                         break
         code_elements = list(filter(lambda x: not(isinstance(x.code_elm, CodeElementImport)), code_elements))
-        all_imports = {x: all_imports[x] for x in temp_import_order_names if len(all_imports[x]) > 1}
+        all_imports = {x: all_imports[x] for x in self.import_order_names}
         
         ordered_imports = []
         for _, v in all_imports.items():
             ordered_imports += v
         elm.code_elements = [code_elements[0]] + ordered_imports + code_elements[1:]
-        return elm.code_elements
     
-    def get_empty_element(self, cairo_module):
-        code_elements = cairo_module.code_elements
-        for x in code_elements:
-                if isinstance(x.code_elm, CodeElementEmptyLine):
-                    res = x
-                    break
-        return res
+    def get_empty_element(self):
+        return CommentedCodeElement(code_elm=CodeElementEmptyLine(), comment=None, location=None)
     
 
     def create_ordered_imports(self, cairo_module):

--- a/src/starknet_interface_generator/order_imports.py
+++ b/src/starknet_interface_generator/order_imports.py
@@ -1,0 +1,42 @@
+from starkware.cairo.lang.compiler.ast.code_elements import CodeBlock, CodeElementImport
+from starkware.cairo.lang.compiler.ast.visitor import Visitor
+
+class OrderImports(Visitor):
+    """
+    Orders imports in Cairo files
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def _visit_default(self, obj):
+        # top-level code is not generated
+        return obj
+    
+    def visit_CodeBlock(self, elm: CodeBlock):
+        return self.extract_imports(elm)
+    
+    def extract_imports(self, elm):
+        starkware = []
+        oz = []
+        rest = []
+        for x in elm.code_elements:
+            if isinstance(x.code_elm, CodeElementImport):
+                if (len(x.code_elm.import_items) > 1):
+                    import_names =  "".join(item.orig_identifier.name + ", " for item in x.code_elm.import_items)
+                else:
+                    import_names = x.code_elm.import_items[0].orig_identifier.name
+                import_str = "from " + x.code_elm.path.name + " import " + import_names
+                if ("starkware" in import_str):
+                    starkware.append(import_str)
+                elif ("openzeppelin" in import_str):
+                    oz.append(import_str)
+                else:
+                    rest.append(import_str)
+        all_import = starkware + oz + rest
+        all_import_str = "".join(x + "\\n" for x in all_import)
+        return all_import_str
+    
+    def create_ordered_imports(self, cairo_module):
+        res = self.visit(cairo_module).cairo_file.code_block
+        return res

--- a/test/main.cairo
+++ b/test/main.cairo
@@ -1,4 +1,5 @@
 %lang starknet
+
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 
 from test.types import ImportedStruct

--- a/test/main_imports_test.cairo
+++ b/test/main_imports_test.cairo
@@ -1,14 +1,14 @@
 %lang starknet
 
-from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.alloc import alloc
-from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 from starkware.cairo.common.math import assert_nn_le, unsigned_div_rem
-from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.math_cmp import is_le, is_nn
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.memset import memset
 from starkware.cairo.common.pow import pow
+from starkware.cairo.common.registers import get_fp_and_pc
 
 from test.types import ImportedStruct
 

--- a/test/main_imports_test.cairo
+++ b/test/main_imports_test.cairo
@@ -1,0 +1,40 @@
+%lang starknet
+
+from test.types import ImportedStruct
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.math import assert_nn_le, unsigned_div_rem
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.memset import memset
+from starkware.cairo.common.pow import pow
+
+struct MyStruct {
+    index: felt,
+}
+
+@storage_var
+func storage_skipped() -> (res: felt) {
+}
+
+@external
+func struct_in_arg{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    amount: felt, _struct: MyStruct, array_len: felt, array: felt*
+) {
+    return ();
+}
+
+@view
+func struct_ptr_in_return{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    res_len: felt, res: felt*, arr_len: felt, arr: ImportedStruct*
+) {
+    return (1, new (1), 1, new ImportedStruct(0));
+}
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    return ();
+}

--- a/test/main_imports_test.cairo
+++ b/test/main_imports_test.cairo
@@ -1,7 +1,5 @@
 %lang starknet
 
-from test.types import ImportedStruct
-
 from starkware.cairo.common.cairo_builtins import HashBuiltin
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.registers import get_fp_and_pc
@@ -11,6 +9,8 @@ from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.memset import memset
 from starkware.cairo.common.pow import pow
+
+from test.types import ImportedStruct
 
 struct MyStruct {
     index: felt,

--- a/test/nested_test/main_imports_test_nested.cairo
+++ b/test/nested_test/main_imports_test_nested.cairo
@@ -1,0 +1,40 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.registers import get_fp_and_pc
+from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
+from starkware.cairo.common.math import assert_nn_le, unsigned_div_rem
+from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.memcpy import memcpy
+from starkware.cairo.common.memset import memset
+from starkware.cairo.common.pow import pow
+
+from test.types import ImportedStruct
+
+struct MyStruct {
+    index: felt,
+}
+
+@storage_var
+func storage_skipped() -> (res: felt) {
+}
+
+@external
+func struct_in_arg{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    amount: felt, _struct: MyStruct, array_len: felt, array: felt*
+) {
+    return ();
+}
+
+@view
+func struct_ptr_in_return{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    res_len: felt, res: felt*, arr_len: felt, arr: ImportedStruct*
+) {
+    return (1, new (1), 1, new ImportedStruct(0));
+}
+
+@constructor
+func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() {
+    return ();
+}


### PR DESCRIPTION
This PR proposes imports ordering feature. It is introduced as a separate command. Files are changed in place, so git history will only contain changing import lines.